### PR TITLE
gcc8: fixing unnecessary parentheses and  catching polymorphic type

### DIFF
--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -606,7 +606,7 @@ bool Parser::isValidNumberLiteral(string const& _literal)
 {
 	try
 	{
-		u256(_literal);
+		u256 _literal;
 	}
 	catch (...)
 	{

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -117,7 +117,7 @@ bool hashMatchesContent(string const& _hash, string const& _content)
 	{
 		return dev::h256(_hash) == dev::keccak256(_content);
 	}
-	catch (dev::BadHexCharacter)
+	catch (dev::BadHexCharacter&)
 	{
 		return false;
 	}
@@ -366,7 +366,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 				// @TODO use libraries only for the given source
 				libraries[library] = h160(address);
 			}
-			catch (dev::BadHexCharacter)
+			catch (dev::BadHexCharacter&)
 			{
 				return formatFatalError(
 					"JSONError",


### PR DESCRIPTION
fixing unnecessary parentheses (-Werror=parentheses) and  catching polymorphic type (-Werror=catch-value)